### PR TITLE
Fixed back navigation on second page

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -91,7 +91,7 @@ class admin_plugin_loglog extends DokuWiki_Admin_Plugin {
         echo '</table>';
 
         echo '<div class="pagenav">';
-        if($max < time()-(7*24*60*60)){
+        if($max < time()){
         echo '<div class="pagenav-prev">';
         echo html_btn('newer',$ID,"p",array('do'=>'admin','page'=>'loglog','time'=>$max+(7*24*60*60)));
         echo '</div>';


### PR DESCRIPTION
Fixed a bug where the back (newer entries) button didn't show on second page.

Steps to reproduce:

1. Go to loglog page, first page appears
2. Click the "less recent >>" button
3. On the second page, I would expect a button labelled "<< more recent" to return to the first page

Maybe this is somewhat related with the hour advance to trick navigation, but didn't test verbosely. This fix seems to do the trick and doesn't seem to affect other functionalities.