### PR TITLE
fix table display when username is too long

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,5 +1,7 @@
 table.loglog {
     width: 80%;
+    table-layout: fixed;
+    word-wrap: break-word;
 }
 
 table.loglog span.loglog_off {


### PR DESCRIPTION
This a simple css fix to be able to see the Action column when Username is too long.
