### PR TITLE
Weekly pagination of Login/Logoff table 

### DIFF
--- a/action.php
+++ b/action.php
@@ -19,7 +19,7 @@ class action_plugin_loglog extends DokuWiki_Action_Plugin {
     /**
      * register the eventhandlers
      */
-    function register(&$controller) {
+    public function register(Doku_Event_Handler $controller) {
         $controller->register_hook(
             'ACTION_ACT_PREPROCESS',
             'BEFORE',

--- a/action.php
+++ b/action.php
@@ -9,8 +9,8 @@
 // must be run within Dokuwiki
 if(!defined('DOKU_INC')) die();
 
-if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN',DOKU_INC.'lib/plugins/');
-require_once(DOKU_PLUGIN.'action.php');
+if(!defined('DOKU_PLUGIN')) define('DOKU_PLUGIN', DOKU_INC . 'lib/plugins/');
+require_once(DOKU_PLUGIN . 'action.php');
 
 class action_plugin_loglog extends DokuWiki_Action_Plugin {
 
@@ -19,49 +19,101 @@ class action_plugin_loglog extends DokuWiki_Action_Plugin {
     /**
      * register the eventhandlers
      */
-    function register(&$controller){
-        $controller->register_hook('ACTION_ACT_PREPROCESS',
-                                   'BEFORE',
-                                   $this,
-                                   'handle_before',
-                                   array());
-        $controller->register_hook('ACTION_AUTH_AUTOLOGOUT','BEFORE',$this,'handle_autologout',array());
-    }
+    function register(&$controller) {
+        $controller->register_hook(
+            'ACTION_ACT_PREPROCESS',
+            'BEFORE',
+            $this,
+            'handle_before',
+            array()
+        );
 
-    function _log($msg){
-        global $conf;
+        // allow other plugins to emit logging events
+        $controller->register_hook(
+            'PLUGIN_LOGLOG_LOG',
+            'BEFORE',
+            $this,
+            'handle_custom',
+            array()
+        );
 
-        $user = $_SERVER['REMOTE_USER'];
-        if(!$user) $user = $_REQUEST['u'];
-
-        $t   = time();
-        $log = $t."\t".strftime($conf['dformat'],$t)."\t".$_SERVER['REMOTE_ADDR']."\t".$user."\t".$msg;
-        io_saveFile($conf['cachedir'].'/loglog.log',"$log\n",true);
+        // autologout plugin
+        $controller->register_hook(
+            'ACTION_AUTH_AUTOLOGOUT',
+            'BEFORE',
+            $this,
+            'handle_autologout',
+            array()
+        );
     }
 
     /**
-     * @param Doku_Event $event
-     * @param mixed      $param   data passed to the event handler
+     * Log an action
+     *
+     * @param $msg
+     * @param null|string $user
      */
-    function handle_autologout (&$event, $param){
+    protected function _log($msg, $user = null) {
+        global $conf;
+        global $INPUT;
+
+        if(is_null($user)) $user = $INPUT->server->str('REMOTE_USER');
+        if(!$user) $user = $_REQUEST['u'];
+        if(!$user) return;
+
+        $t   = time();
+        $log = $t . "\t" . strftime($conf['dformat'], $t) . "\t" . $_SERVER['REMOTE_ADDR'] . "\t" . $user . "\t" . $msg;
+        io_saveFile($conf['cachedir'] . '/loglog.log', "$log\n", true);
+    }
+
+    /**
+     * Handle custom logging events
+     *
+     * @param Doku_Event $event
+     * @param mixed $param data passed to the event handler
+     */
+    public function handle_custom(Doku_Event $event, $param) {
+        if(isset($event->data['message'])) {
+            $log = $event->data['message'];
+        } else {
+            return;
+        }
+        if(isset($event->data['user'])) {
+            $user = $event->data['user'];
+        } else {
+            $user = null;
+        }
+
+        $this->_log($log, $user);
+    }
+
+    /**
+     * Handle autologoffs by the autologout plugin
+     *
+     * @param Doku_Event $event
+     * @param mixed $param data passed to the event handler
+     */
+    public function handle_autologout(Doku_Event $event, $param) {
         $this->_log('has been automatically logged off');
     }
 
-
     /**
-     * catch logouts
+     * catch standard logins/logouts
+     *
+     * @param Doku_Event $event
+     * @param mixed $param data passed to the event handler
      */
     public function handle_before(Doku_Event $event, $param) {
         $act = act_clean($event->data);
         if($act == 'logout') {
             $this->_log('logged off');
-        }elseif($_SERVER['REMOTE_USER'] && $act=='login'){
-            if($_REQUEST['r']){
+        } elseif($_SERVER['REMOTE_USER'] && $act == 'login') {
+            if($_REQUEST['r']) {
                 $this->_log('logged in permanently');
-            }else{
+            } else {
                 $this->_log('logged in temporarily');
             }
-        }elseif($_REQUEST['u'] && !$_REQUEST['http_credentials'] && !$_SERVER['REMOTE_USER']){
+        } elseif($_REQUEST['u'] && !$_REQUEST['http_credentials'] && !$_SERVER['REMOTE_USER']) {
             $this->_log('failed login attempt');
         }
     }

--- a/action.php
+++ b/action.php
@@ -51,9 +51,9 @@ class action_plugin_loglog extends DokuWiki_Action_Plugin {
     /**
      * catch logouts
      */
-    function handle_before(&$event, $param){
-        $act = $this->_act_clean($event->data);
-        if($act == 'logout'){
+    public function handle_before(Doku_Event $event, $param) {
+        $act = act_clean($event->data);
+        if($act == 'logout') {
             $this->_log('logged off');
         }elseif($_SERVER['REMOTE_USER'] && $act=='login'){
             if($_REQUEST['r']){
@@ -65,26 +65,5 @@ class action_plugin_loglog extends DokuWiki_Action_Plugin {
             $this->_log('failed login attempt');
         }
     }
-
-
-
-    /**
-     * Pre-Sanitize the action command
-     *
-     * Similar to act_clean in action.php but simplified and without
-     * error messages
-     */
-    function _act_clean($act){
-         // check if the action was given as array key
-         if(is_array($act)){
-           list($act) = array_keys($act);
-         }
-
-         //remove all bad chars
-         $act = strtolower($act);
-         $act = preg_replace('/[^a-z_]+/','',$act);
-
-         return $act;
-     }
 }
 

--- a/admin.php
+++ b/admin.php
@@ -33,9 +33,9 @@ class admin_plugin_loglog extends DokuWiki_Admin_Plugin {
      * output appropriate html
      */
     function html() {
-        global $conf;
-        global $lang;
-        $go  = (int) $_REQUEST['time'];
+        global $conf, $lang, $INPUT;
+
+        $go  = $INPUT->int('time');
         if(!$go) $go = strtotime('monday this week');
         $min = $go;
         $max = strtotime('+1 week',$min);

--- a/admin.php
+++ b/admin.php
@@ -43,7 +43,7 @@ class admin_plugin_loglog extends DokuWiki_Admin_Plugin {
         echo $this->locale_xhtml('intro');
 
         echo '<p>'.$this->getLang('range').' '.strftime($conf['dformat'],$min).
-             ' - '.strftime($conf['dformat'],$max).'</p>';
+             ' - '.strftime($conf['dformat'],$max-1).'</p>';
 
 
         echo '<table class="inline loglog">';

--- a/admin.php
+++ b/admin.php
@@ -36,9 +36,9 @@ class admin_plugin_loglog extends DokuWiki_Admin_Plugin {
         global $conf;
         global $lang;
         $go  = (int) $_REQUEST['time'];
-        if(!$go) $go = time()+60*60; //one hour in the future to trick pagination
-        $min = $go-(7*24*60*60);
-        $max = $go;
+        if(!$go) $go = strtotime('monday this week');
+        $min = $go;
+        $max = strtotime('+1 week',$min);
 
         echo $this->locale_xhtml('intro');
 
@@ -104,14 +104,14 @@ class admin_plugin_loglog extends DokuWiki_Admin_Plugin {
         echo '</table>';
 
         echo '<div class="pagenav">';
-        if($max < time()-(7*24*60*60)){
+        if ($max <= $_SERVER['REQUEST_TIME']){
         echo '<div class="pagenav-prev">';
-        echo html_btn('newer',$ID,"p",array('do'=>'admin','page'=>'loglog','time'=>$max+(7*24*60*60)));
+        echo html_btn('newer',$ID,"p",array('do'=>'admin','page'=>'loglog','time'=>$max));
         echo '</div>';
         }
 
         echo '<div class="pagenav-next">';
-        echo html_btn('older',$ID,"n",array('do'=>'admin','page'=>'loglog','time'=>$min));
+        echo html_btn('older',$ID,"n",array('do'=>'admin','page'=>'loglog','time'=>strtotime('-1 week',$min)));
         echo '</div>';
         echo '</div>';
 
@@ -168,7 +168,7 @@ class admin_plugin_loglog extends DokuWiki_Admin_Plugin {
             // get date of first line:
             list($cdate) = explode("\t",$cparts[0]);
 
-            if($cdate > $max) continue; // haven't reached wanted area, yet
+            if($cdate >= $max) continue; // haven't reached wanted area, yet
 
             // put the new lines on the stack
             $lines = array_merge($cparts,$lines);

--- a/admin.php
+++ b/admin.php
@@ -104,7 +104,7 @@ class admin_plugin_loglog extends DokuWiki_Admin_Plugin {
         echo '</table>';
 
         echo '<div class="pagenav">';
-        if ($max <= $_SERVER['REQUEST_TIME']){
+        if ($max < time()){
         echo '<div class="pagenav-prev">';
         echo html_btn('newer',$ID,"p",array('do'=>'admin','page'=>'loglog','time'=>$max));
         echo '</div>';

--- a/lang/ja/lang.php
+++ b/lang/ja/lang.php
@@ -4,6 +4,7 @@
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
  * 
  * @author Hideaki SAWADA <chuno@live.jp>
+ * @author Satoshi Sahara <sahara.satoshi@gmail.com>
  */
 $lang['menu']                  = '週間ユーザーログイン／ログアウト';
 $lang['date']                  = '日付';
@@ -11,6 +12,7 @@ $lang['ip']                    = 'IPアドレス';
 $lang['action']                = '動作';
 $lang['range']                 = '表示中の日付範囲：';
 $lang['off']                   = 'ログオフ';
+$lang['autologoff']            = '自動ログオフの検出';
 $lang['in']                    = '恒久的なログイン';
 $lang['tin']                   = '一時的なログイン';
 $lang['fail']                  = 'ログイン失敗';

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    loglog
 author  Andreas Gohr
-email   andi@splitbrain.org
-date    2015-03-10
+email   dokuwiki@cosmocode.de
+date    2015-05-04
 name    Login/Logout logging plugin
 desc    Log logins and logouts of users to a file
 url     http://www.dokuwiki.org/plugin:loglog


### PR DESCRIPTION
This request makes the pagination of User Logins/Logouts table weekly, from Monday to Sunday. 

It may be convenient for admin to allow checking user login events during working days of every weeks. This request also covers pull request #8 by @leplastic about 1 year ago.

