### PR TITLE
Fix for failed login attempt

### DIFF
--- a/action.php
+++ b/action.php
@@ -107,14 +107,16 @@ class action_plugin_loglog extends DokuWiki_Action_Plugin {
         $act = act_clean($event->data);
         if($act == 'logout') {
             $this->_log('logged off');
-        } elseif(!empty($_SERVER['REMOTE_USER']) && $act == 'login') {
-            if(isset($_REQUEST['r'])) {
-                $this->_log('logged in permanently');
+        } elseif($act == 'login') {
+            if(!empty($_SERVER['REMOTE_USER'])) {
+                if(isset($_REQUEST['r'])) {
+                    $this->_log('logged in permanently');
+                } else {
+                    $this->_log('logged in temporarily');
+                }
             } else {
-                $this->_log('logged in temporarily');
+                $this->_log('failed login attempt');
             }
-        } elseif($_REQUEST['u'] && $_REQUEST['http_credentials'] && empty($_SERVER['REMOTE_USER'])) {
-            $this->_log('failed login attempt');
         }
     }
 }


### PR DESCRIPTION
In release "Elenor of Tsort" this plugin does not log failed login attempts.
This pull request fixes this.
I think it also closes #31 (compatibility with "Frusterick Manners"), but I can't test that.

**Tests done with `authplain` only.**

_Note:_
The code refers to an `autologout` plugin, but this plugin could not be found on the DokuWiki site.
Could this part be trimmed off?
(_Edit:_ I've found it. The plugin is named `autologoff`.)